### PR TITLE
panel.cpp: anchor adjacent edges

### DIFF
--- a/panel.cpp
+++ b/panel.cpp
@@ -247,10 +247,10 @@ void Panel::init()
     layer_shell_surface = layer_shell.get_layer_surface(surface, output, zwlr_layer_shell_v1_layer::top, std::string("Window"));
     switch(Settings::get_settings()->panel_position()) {
       case PanelPosition::TOP:
-        layer_shell_surface.set_anchor(zwlr_layer_surface_v1_anchor::top);
+        layer_shell_surface.set_anchor(zwlr_layer_surface_v1_anchor::top | zwlr_layer_surface_v1_anchor::right | zwlr_layer_surface_v1_anchor::left);
         break;
       default:
-        layer_shell_surface.set_anchor(zwlr_layer_surface_v1_anchor::bottom);
+        layer_shell_surface.set_anchor(zwlr_layer_surface_v1_anchor::bottom | zwlr_layer_surface_v1_anchor::right | zwlr_layer_surface_v1_anchor::left);
     }
     layer_shell_surface.set_size(m_width, m_height);
     layer_shell_surface.set_exclusive_zone(Settings::get_settings()->exclusive_zone());


### PR DESCRIPTION
...in order to work with labwc and wlroots 0.16.0 scene-graph API.

The layer-shell protocol specifies that a positive exclusive-zone value is 'meaningful' if the surface is anchored to either:

1. one edge
2. one edge and both perpendicular edges.

For example, with position=top and exclusive=true, you should be able to set either anchor=TOP or anchor=TOP|LEFT|RIGHT. The wlroots 0.16.0 scene-graph API currently only supports the second case and it appears that many panels/bars use that approach (anchor to an edge and also both perpendicular edges) which is probably why this has not been discovered previously.

A Merge Request has been submitted to the wlroots project, but the release cycle is quite slow, so I wanted to offer this solution in order not to inconvenience users.

https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3884